### PR TITLE
Add compute-roles, BMR, and site-config-schema patterns (netstack#18)

### DIFF
--- a/docs/ops/deployments/bmr-pattern.md
+++ b/docs/ops/deployments/bmr-pattern.md
@@ -1,0 +1,167 @@
+# Bare Metal Rebuild (BMR) Pattern
+
+**Purpose:** Define the scripted rebuild path for federation site infrastructure.
+**Implementation:** [netstack#17](https://github.com/2cld/netstack/issues/17) (contains bootstrap.sh reference implementation)
+**Exemplar:** [wf compute architecture](https://github.com/2cld/wf/blob/main/ops/compute/wf-compute-architecture.md)
+**Related:** [netstack#18](https://github.com/2cld/netstack/issues/18), [compute-roles-pattern](./compute-roles-pattern.md)
+
+---
+
+## The Problem
+
+If a site's infra node dies, recovery depends on tribal knowledge. The pieces exist (site-config.yml, Docker compose files, backup scripts) but there's no single documented path from "fresh hardware" to "site operational."
+
+## The Pattern: Four-Script Rebuild
+
+BMR targets the **infra role** (see [compute-roles-pattern](./compute-roles-pattern.md)). Four scripts, executed in order, take a fresh machine to full operation:
+
+```bash
+# On fresh Ubuntu (bare metal, VM, LXC, RPi, or WSL):
+git clone git@github.com:2cld/<site>.git
+cd <site>/ops
+./bootstrap.sh site-config.yml    # OS config, users, deps, keys, cron
+./deploy.sh site-config.yml       # Docker stack, tunnels, services
+./restore.sh site-config.yml --from <backup-source>   # Pull data from off-site
+./verify.sh site-config.yml       # Confirm everything matches expected state
+```
+
+Each script reads `site-config.yml` as its single source of truth.
+
+## Script Responsibilities
+
+### bootstrap.sh -- Provision the OS
+
+| Step | What | Reads from config |
+|------|------|------------------|
+| 1 | Set timezone | `site.timezone` |
+| 2 | Install packages (openssh, docker, yq, git, curl) | implicit |
+| 3 | Create users (buadmin, wip) per federation-user-model | `compute.roles.infra.users` |
+| 4 | Generate SSH keys per user | -- |
+| 5 | Create directory structure | -- |
+| 6 | Clone repos (site repo, netstack, wip) | `site.repo` |
+| 7 | Set up cron (backup, monitoring) | `monitoring`, `federation` |
+| 8 | Enable Docker | -- |
+| 9 | Join ZeroTier network | `zerotier.networks[0].id` |
+
+**Output:** A provisioned machine with users, Docker, ZeroTier, and cron -- but no services running yet.
+
+**Reference implementation:** [netstack#17](https://github.com/2cld/netstack/issues/17) contains a full bootstrap.sh.
+
+### deploy.sh -- Start Services
+
+| Step | What | Reads from config |
+|------|------|------------------|
+| 1 | Pull Docker images | `services[*].image` |
+| 2 | Generate docker-compose.yml from config | `services[*]` |
+| 3 | Configure Cloudflare tunnel | `services[*].tunnel` |
+| 4 | Configure Traefik routes | `services[*].url` |
+| 5 | Start Docker stack | -- |
+| 6 | Verify services responding | `services[*].port` |
+
+**Output:** All services running, tunnel active, site reachable remotely.
+
+### restore.sh -- Pull Backup Data
+
+| Step | What | Reads from config |
+|------|------|------------------|
+| 1 | Identify backup source | `federation.backup_from` or `--from` flag |
+| 2 | SSH to source, verify backup freshness | source's `.backup-state` |
+| 3 | rsync data from source to local paths | `services[*].volumes` |
+| 4 | Restore database dumps (if any) | `services[*].backup.restore_cmd` |
+| 5 | Restart services with restored data | -- |
+
+**Output:** Services running with real data (not empty). Site is fully operational.
+
+### verify.sh -- Confirm Healthy State
+
+| Step | What | Reads from config |
+|------|------|------------------|
+| 1 | Check each service is responding | `services[*].port` |
+| 2 | Check ZeroTier connected | `zerotier.networks` |
+| 3 | Check tunnel healthy | `services[*].tunnel` |
+| 4 | Check backup script runs | `federation.role` |
+| 5 | Check cron installed | -- |
+| 6 | Run .wip-monitor.yml checks | `.wip-monitor.yml` |
+| 7 | Produce site-status.json | -- |
+
+**Output:** Pass/fail report. If all pass, site is confirmed operational.
+
+## What Lives Where
+
+| Component | Location | Why |
+|-----------|----------|-----|
+| Pattern docs (this file) | netstack `docs/ops/deployments/` | Shared knowledge -- HOW |
+| Script templates | ns-site-template (gitea.cat9.me) | Generic scaffolding |
+| site-config.yml | Site repo (cf, sl, wf) | Site-specific values -- WHAT |
+| .wip-monitor.yml | Site repo | Monitoring contract |
+| .wip-contract.md | Site repo | Communication contract |
+| Docker compose | Site repo `ops/docker/` | Service definitions |
+| Backup scripts | Site repo `ops/scripts/` | Site-specific backup logic |
+
+**The contract between generic and specific:**
+- Scripts read `site-config.yml` keys
+- If a key exists, the script acts on it
+- If a key is missing, the script skips that step (graceful degradation)
+- Site repos can override/extend with site-specific scripts in `ops/scripts/`
+
+## BMR Scope: What Gets Rebuilt vs. What Gets Restored
+
+| Category | Rebuilt by scripts | Restored from backup |
+|----------|:-:|:-:|
+| OS + packages | bootstrap.sh | -- |
+| Users + SSH keys | bootstrap.sh | -- (new keys, register on remotes) |
+| Docker services | deploy.sh | -- |
+| Tunnel config | deploy.sh | -- |
+| Application data (DBs, repos) | -- | restore.sh |
+| Media files | -- | restore.sh (or accept loss if reproducible) |
+| Cron jobs | bootstrap.sh | -- |
+| ZeroTier membership | bootstrap.sh | -- (re-authorize in Central) |
+
+## Platform Support
+
+| Platform | bootstrap.sh | deploy.sh | Notes |
+|----------|:-:|:-:|-------|
+| Ubuntu 22.04+ (bare metal) | YES | YES | Primary target |
+| Proxmox LXC (Ubuntu) | YES | YES | wf Phase 1 |
+| Raspberry Pi OS (arm64) | YES | YES | wf Phase 2 |
+| WSL2 (Ubuntu on Windows) | PARTIAL | YES | sl pattern -- some steps differ (no systemd) |
+| MikroTik RouterOS containers | NO | PARTIAL | Different runtime -- document separately |
+
+## Testing BMR
+
+### Smoke Test (non-destructive)
+```bash
+# On existing infra node:
+./verify.sh site-config.yml
+# Should pass -- confirms current state matches config
+```
+
+### Full DR Test (destructive, controlled)
+1. Provision a fresh VM/LXC (NOT the production node)
+2. Run all four scripts against it
+3. Verify services come up with real data
+4. Tear down test environment
+5. Document results in issue comment
+
+### Cross-Site DR Test (proves portability)
+1. On a DIFFERENT site's hardware, provision a test VM
+2. Clone the target site's repo
+3. Run bootstrap + deploy + restore
+4. Verify the site works from different physical hardware
+5. This proves: if site X dies, it can be rebuilt at site Y
+
+## Migration Path (for sites not yet BMR-ready)
+
+1. **Write verify.sh first** -- confirms what you HAVE matches what config SAYS
+2. **Write deploy.sh** -- automates what you do manually today to start services
+3. **Write bootstrap.sh** -- automates the OS provisioning you did once and forgot
+4. **Write restore.sh** -- automates pulling backup data
+5. **Test on a disposable VM** -- don't test on production
+
+## Related Patterns
+
+- [Compute Roles Pattern](./compute-roles-pattern.md) -- defines which hardware role is the BMR target
+- [Federation User Model](./federation-user-model-pattern.md) -- user roles created by bootstrap.sh
+- [Compute WSL Docker Pattern](./compute-wsl-docker-pattern.md) -- WSL-specific deployment (sl)
+- [Site Tenant Contract](./site-tenant-contract-pattern.md) -- .wip-contract.md defines scope
+- [Contract-Driven Monitoring](../monitor/contract-driven-monitoring-pattern.md) -- .wip-monitor.yml drives verify.sh

--- a/docs/ops/deployments/compute-roles-pattern.md
+++ b/docs/ops/deployments/compute-roles-pattern.md
@@ -1,0 +1,171 @@
+# Compute Roles Pattern
+
+**Purpose:** Define standard compute-role taxonomy for federation sites.
+**Exemplar:** [wf compute architecture](https://github.com/2cld/wf/blob/main/ops/compute/wf-compute-architecture.md)
+**Related:** [netstack#17](https://github.com/2cld/netstack/issues/17) (BMR), [netstack#18](https://github.com/2cld/netstack/issues/18)
+
+---
+
+## The Problem
+
+Federation sites tend to collapse all workloads onto one machine: always-on infrastructure, cold storage, and ad-hoc workbench tasks all share hardware. This creates conflicts:
+
+- A tunnel server forces a 200W storage box to run 24/7
+- Sort/triage work risks the archival pool
+- Power profiles (always-on vs. cold vs. ad-hoc) fight each other
+
+## The Pattern: Role-Based Compute Assignment
+
+Every site assigns hardware to one of four standard roles based on power profile and uptime requirements:
+
+| Role | Power Profile | Uptime | BMR Target? | Purpose |
+|------|--------------|--------|:-----------:|---------|
+| **infra** | Always-on, low power (5-15W) | 24/7 | YES | Tunnels, monitoring, WoL triggers, coordination |
+| **glacial** | Mostly OFF, WoL-scheduled | Scheduled windows | No | Cold storage, backup receive, archival media |
+| **recovery** | Manual, powered during active recovery | As-needed | No | Data recovery from old/damaged media |
+| **sort** | Manual, powered when physically present | As-needed | No | Drive triage, indexing, data migration workbench |
+
+Not every site needs all four roles. A minimal site (like sl) might only have **infra** (WSL Docker on the one machine). A site with heavy storage (like wf) uses all four.
+
+## Role Definitions
+
+### infra (always-on gateway)
+
+**What it does:**
+- Runs Cloudflare tunnel (remote visibility)
+- Runs Traefik (reverse proxy for local services)
+- Runs monitoring (site-status.sh, produces site-status.json)
+- Sends WoL packets to wake glacial/recovery units on schedule
+- Hosts coordination services (Portainer, optional web dashboard)
+
+**Hardware requirements:**
+- Low power draw (target: under 15W idle)
+- SSD only (no spinning drives)
+- Network connectivity (wired ethernet + ZeroTier)
+- Reliable (this is the DR-critical piece - if infra dies, remote visibility goes dark)
+
+**Candidate platforms:**
+- Raspberry Pi 5 (8GB) - 5W, ARM64, proven Docker support
+- Mini-PC (Intel N100 class) - 10W, x86_64, full compat
+- MikroTik (container-capable models: hAP ax3, RB5009) - RouterOS 7.4+, requires ARM64/x86 + 1GB+ RAM
+- Proxmox LXC on existing hardware - 0W extra (but forces host to stay on)
+- Old laptop with SSD - 15W, built-in UPS (battery)
+
+**MikroTik note:** Only higher-end models support containers. Requirements: RouterOS v7.4+, ARM64 or x86 CPU, 1GB+ RAM. Models like RB951G (128MB RAM) CANNOT run containers - they remain network gateway (ng) role only.
+
+**BMR:** This is the primary BMR target. `bootstrap.sh` from netstack#17 rebuilds this role from `site-config.yml`.
+
+### glacial (cold storage)
+
+**What it does:**
+- Holds large storage pools (ZFS, btrfs, or raw partitions)
+- Accepts backup writes on schedule (rsync from other sites)
+- Runs health checks (pool scrub, SMART) when awake
+- Shuts down after completing scheduled work
+
+**Hardware requirements:**
+- Multiple drive bays (4+ SATA for meaningful ZFS pools)
+- WoL-capable NIC (wakes on schedule from infra)
+- Does NOT need to be low-power (it's mostly off)
+- Reliable storage controller
+
+**Candidate platforms:**
+- 1U rackmount servers (SR1580SFHS, Dell R610, etc.) - good drive density
+- Tower servers with multiple bays
+- NAS appliances (Synology, TrueNAS) if available
+
+**Multi-unit pattern:** Sites with multiple clients or isolation requirements can run multiple glacial units - one per client. Each unit has independent WoL schedule, independent failure domain.
+
+**Operational pattern:**
+```
+infra sends WoL -> glacial boots -> mounts pool -> backup job runs
+-> health check -> reports status -> shuts down -> infra logs result
+```
+
+### recovery (temporary data extraction)
+
+**What it does:**
+- Mounts drives from decommissioned/damaged hardware (NAS, old servers)
+- Runs indexing scripts to discover what's on the drives
+- Stages recovered data for triage (what to keep vs. discard)
+- Temporary role - once recovery is complete, hardware gets repurposed
+
+**Hardware requirements:**
+- Compatible drive interface (SATA backplane, SAS card, or USB)
+- Enough RAM/CPU to run indexing scripts
+- LAN connectivity (to transfer recovered data to glacial units)
+- Does NOT need ZeroTier, tunnels, or remote access
+
+**Lifecycle:** Recovery is a temporary role. Once data is extracted and migrated to glacial storage, the hardware either becomes another glacial unit or gets decommissioned.
+
+### sort (workbench)
+
+**What it does:**
+- Connects bulk drives (USB shelves, SAS arrays) for indexing and triage
+- Runs index-device scripts, generates manifests
+- Stages data on local storage during sort operations
+- Physically present work - requires hands on hardware
+
+**Hardware requirements:**
+- Many I/O ports (SAS card, USB 3.0 ports, multiple SATA)
+- Large local staging area (SSD or fast HDD for temporary data)
+- Physical access (not remote-operated)
+- Does NOT need network services, tunnels, or WoL
+
+**What happens to sorted data:**
+- Irreplaceable (home video, personal docs) -> glacial units
+- Reproducible but costly (DVD rips, CD rips) -> glacial units (lower priority)
+- Reproducible and easy (DVR recordings) -> delete
+- Disposable (temp files, caches) -> wipe drive
+
+## site-config.yml Integration
+
+Sites declare compute roles in their `site-config.yml`:
+
+```yaml
+compute:
+  roles:
+    infra:
+      host: rpi5
+      platform: docker
+      always_on: true
+      bmr_target: true
+    glacial:
+      - host: 1u-srv-01
+        platform: linux
+        wol_mac: "AA:BB:CC:DD:EE:01"
+        schedule: "0 2 * * 0"
+        client: "federation"
+    recovery:
+      host: 1u-srv-sg
+      purpose: "Synology sg drive extraction"
+      temporary: true
+    sort:
+      host: cg2
+      purpose: "USB shelf + SAS drive triage"
+```
+
+## Mapping Your Site
+
+To apply this pattern:
+
+1. **Inventory your hardware** - what machines exist at the site?
+2. **Identify the power profiles** - what MUST be always-on? What can sleep?
+3. **Assign roles** - match hardware to roles based on power profile + capabilities
+4. **Document in site-config.yml** - add `compute.roles` section
+5. **Plan migration** - if everything is on one box today, plan phased separation
+
+## Examples
+
+| Site | infra | glacial | recovery | sort |
+|------|-------|---------|----------|------|
+| wf | LXC 100 (Phase 1) -> RPi 5 (Phase 2) | 1U fleet (per-client) | 1U with sg drives | cg2 (SAS card) |
+| sl | slwin11ops (WSL Docker) | slwin11ops (same machine, backup-receive only) | -- | -- |
+| cf | nsdockerhv (Docker VM on CyberTruck) | CyberTruck local storage | -- | -- |
+
+## Related Patterns
+
+- [BMR Pattern](./bmr-pattern.md) - how to rebuild the infra role from scratch
+- [Federation Node Topology](./federation-node-topology.md) - standard node structure
+- [Federation User Model](./federation-user-model-pattern.md) - user roles per node
+- [site-config-physical-schema.md](./site-config-physical-schema.md) - physical inventory format

--- a/docs/ops/deployments/site-config-schema.md
+++ b/docs/ops/deployments/site-config-schema.md
@@ -1,0 +1,272 @@
+# site-config.yml Schema
+
+**Purpose:** Document the canonical keys that site-config.yml files use across the federation.
+**Consumers:** ns-site-template scripts (generate-site.sh, generate-docs.sh, collect-site.sh), BMR scripts (bootstrap.sh, deploy.sh, restore.sh, verify.sh)
+**Related:** [site-config-physical-schema.md](./site-config-physical-schema.md) (physical inventory extension), [netstack#18](https://github.com/2cld/netstack/issues/18)
+
+---
+
+## Overview
+
+`site-config.yml` is the machine-readable source of truth for each federation site. Every site repo (cf, sl, wf) has one at the repo root. Scripts read it to generate docs, deploy services, monitor health, and rebuild from scratch.
+
+## Schema Sections
+
+### site (required)
+
+Identifies the site. Used by all scripts.
+
+```yaml
+site:
+  code: wf                              # Short identifier (used in scripts, hostnames, paths)
+  name: "Winfield"                      # Human-readable name
+  repo: "https://github.com/2cld/wf"   # Canonical repo URL
+  created: 2024-01-01                   # When site was first documented
+  timezone: "America/Chicago"           # System timezone for cron/logs
+  location: "Physical address"          # Physical address
+  owner: "TreesAES LLC"                 # Legal owner of hardware/location
+  email: "treesaes@gmail.com"           # Owner contact
+  admin: "christrees@gmail.com"         # Technical admin contact
+```
+
+| Key | Required | Used by |
+|-----|:--------:|--------|
+| code | YES | All scripts, hostname generation |
+| name | YES | Docs generation |
+| repo | YES | bootstrap.sh (clone source) |
+| timezone | YES | bootstrap.sh (timedatectl) |
+| location | no | Docs, physical inventory |
+| owner | no | Contract/legal reference |
+| email | no | .wip-contract.md generation |
+| admin | no | Escalation contact |
+
+### network (required)
+
+LAN configuration. Used by bootstrap.sh, generate-docs.sh.
+
+```yaml
+network:
+  subnet: 192.168.9.0/24
+  gateway: 192.168.9.1
+  dns_primary: 1.1.1.1
+  dns_secondary: 8.8.8.8
+  isp: "Starlink"
+  dhcp:
+    enabled: true
+    range_start: 192.168.9.100
+    range_end: 192.168.9.199
+    server: 192.168.9.1
+  netstack_assignments:    # Named roles (ng, sg, cg, etc.)
+    ng:
+      ipv4: 192.168.9.1
+      hostname: mikrotik
+      model: "MikroTik RB951G-2HnD"
+      mac: "00:0C:42:B7:CA:E9"
+      enabled: true
+```
+
+### devices (required)
+
+All network-attached hardware. Used by generate-docs.sh, collect-site.sh.
+
+```yaml
+devices:
+  - hostname: mikrotik
+    type: router          # router, server, workstation, nas, isp, switch
+    role: ng              # netstack role assignment
+    ipv4: 192.168.9.1
+    mac: "00:0C:42:B7:CA:E9"
+    model: "MikroTik RB951G-2HnD"
+    location: wf-ops-rm1  # Physical location tag
+    services:
+      - name: "DHCP"
+        port: 67
+      - name: "Admin"
+        port: 80
+        url: "http://192.168.9.1"
+    notes: "RouterOS 7.5"
+```
+
+### compute (optional -- extends base for BMR)
+
+Virtualization and compute roles. Used by bootstrap.sh, deploy.sh.
+
+```yaml
+compute:
+  host: cg2                # Primary compute host
+  platform: proxmox        # proxmox, docker, wsl, bare-metal
+  access: "https://192.168.9.3:8006"
+
+  # Compute role assignments (per compute-roles-pattern.md)
+  roles:
+    infra:
+      host: lxc-100
+      platform: docker
+      always_on: true
+      bmr_target: true
+    glacial:
+      - host: 1u-srv-01
+        wol_mac: "AA:BB:CC:DD:EE:01"
+        schedule: "0 2 * * 0"
+        client: "federation"
+    recovery:
+      host: 1u-srv-sg
+      purpose: "Synology drive extraction"
+      temporary: true
+    sort:
+      host: cg2
+      purpose: "USB shelf + SAS triage"
+
+  # VMs/containers on the compute host
+  vms:
+    - id: 100
+      name: docker
+      type: lxc            # lxc, vm
+      hostname: docker
+      ip: 192.168.9.11
+      cores: 2
+      memory: 2048
+      disk: "local-lvm:4G"
+      onboot: false
+      status: stopped
+      services:
+        - name: Portainer
+          port: 9443
+```
+
+### storage (optional)
+
+Storage pools and datasets. Used by generate-docs.sh, verify.sh.
+
+```yaml
+storage:
+  pools:
+    - name: MediaVolume
+      type: zfs             # zfs, btrfs, lvm, raw
+      layout: raidz1        # raidz1, mirror, stripe, single
+      host: cg2
+      size_tb: 21.8
+      used_tb: 12.4
+      free_tb: 9.37
+      drives:
+        - serial: Z4D0830X
+          model: ST6000DX000-1H217Z
+      datasets:
+        - name: Media
+          size: "8.86 TB"
+          tier: media        # media, scratch, warm, cold, archive
+```
+
+### services (optional)
+
+Running services. Used by deploy.sh, verify.sh, generate-docs.sh.
+
+```yaml
+services:
+  - name: "wfMedia"
+    type: "media"           # media, infra, backup, web, database
+    application: "Plex"
+    host: cg2
+    vm_id: 101
+    port: 32400
+    status: running
+    access:
+      local: "http://192.168.9.x:32400"
+      remote: "none"
+```
+
+### zerotier (optional)
+
+Overlay network membership. Used by bootstrap.sh.
+
+```yaml
+zerotier:
+  enabled: true
+  networks:
+    - id: d5e5fb65371eb4a4
+      name: cat-ghadmin-grid
+      purpose: federation
+  members:
+    - hostname: devwin10
+      zt_ip: 10.147.17.165
+      networks: [d5e5fb65371eb4a4]
+```
+
+### monitoring (optional)
+
+Monitoring goals and checks. Used by verify.sh, generate-docs.sh.
+
+```yaml
+monitoring:
+  enabled: true
+  script: "ops/scripts/wf-status.sh"
+  goals:
+    - name: "Federation backup target"
+      enabled: true
+      depends:
+        - service: ssh
+          host: devwin10
+          user: buadmin
+          port: 22
+      validated_by: ".backup-state file fresh < 24h"
+      current_status: "OPERATIONAL"
+  checks:
+    - name: devwin10
+      method: ping
+      target: 10.147.17.165
+```
+
+### federation (required)
+
+Cross-site relationships. Used by restore.sh, backup scripts.
+
+```yaml
+federation:
+  name: "2cld.net"
+  role: "bu-1"             # primary, bu-0 (first backup), bu-1 (second backup)
+  backup_from: cf          # Which site sends backups here
+  backup_path: "D:\\cat9bu-wf\\"
+  reference: "https://netstack.org/docs/ops/deployments/"
+```
+
+### physical (optional)
+
+Physical infrastructure (locations, switches, cables, power). See [site-config-physical-schema.md](./site-config-physical-schema.md) for full specification.
+
+## Validation Rules
+
+1. **site.code** must be unique across the federation (cf, sl, wf)
+2. **site.repo** must be a valid git clone URL
+3. **devices[*].hostname** must be unique within the site
+4. **devices[*].ipv4** must be within `network.subnet`
+5. **compute.vms[*].id** must be unique within the compute host
+6. **zerotier.networks[*].id** must be a valid 16-character hex string
+7. **federation.role** must be one of: primary, bu-0, bu-1, bu-2, etc.
+
+## Cross-Site Validation
+
+When validating across all federation sites:
+- No two sites should have the same `site.code`
+- `federation.backup_from` must reference a valid site code
+- ZeroTier network IDs should be consistent across sites that need connectivity
+
+## Current State (validated against actual configs)
+
+| Site | site | network | devices | compute | storage | services | zerotier | monitoring | federation |
+|------|:----:|:-------:|:-------:|:-------:|:-------:|:--------:|:--------:|:----------:|:----------:|
+| cf | YES | YES | YES | YES | YES | YES | YES | YES | YES |
+| sl | YES | YES | YES | YES | YES | YES | YES | YES | YES |
+| wf | YES | YES | YES | YES | YES | YES | YES | YES | YES |
+
+**Gaps identified:**
+- `compute.roles` section (from compute-roles-pattern.md) not yet present in any site config -- proposed addition
+- wf has the most complete config; sl has the most detailed physical inventory
+- cf compute section documents Proxmox VMs but not role assignments
+
+## Related
+
+- [compute-roles-pattern.md](./compute-roles-pattern.md) -- defines the `compute.roles` extension
+- [bmr-pattern.md](./bmr-pattern.md) -- scripts that consume this schema
+- [site-config-physical-schema.md](./site-config-physical-schema.md) -- physical inventory extension
+- [site-docs-generator-pattern.md](./site-docs-generator-pattern.md) -- generating docs from config
+- [ns-site-template](https://gitea.cat9.me/nsadmin/ns-site-template) -- scaffold scripts that read this schema


### PR DESCRIPTION
## Summary

Adds three pattern documents extracted from wf's compute architecture experience, formalizing knowledge that was developed during wf site ops into reusable netstack patterns.

### New documents:

1. **`compute-roles-pattern.md`** - Standard taxonomy for federation compute roles:
   - infra (always-on, low power, BMR target)
   - glacial (cold storage, WoL-scheduled)
   - recovery (temporary data extraction)
   - sort (workbench, manual power-on)
   - Includes site-config.yml integration and per-site examples

2. **`bmr-pattern.md`** - Bare Metal Rebuild pattern:
   - Four-script rebuild path (bootstrap/deploy/restore/verify)
   - What lives where (netstack vs ns-site-template vs site repos)
   - Platform support matrix (Ubuntu, LXC, RPi, WSL, MikroTik)
   - Testing procedures (smoke test, full DR, cross-site DR)
   - References netstack#17 bootstrap.sh as implementation

3. **`site-config-schema.md`** - Canonical schema documentation:
   - All sections (site, network, devices, compute, storage, services, zerotier, monitoring, federation)
   - Required vs optional keys per section
   - Which scripts consume which keys
   - Validation rules and cross-site checks
   - Current state validated against cf, sl, wf configs

### Closes: #18

### Related:
- netstack#17 (BMR implementation - bootstrap.sh)
- netstack#3 (federation deployment across sites)
- wf#9 / wf PR#10 (source material - wf compute architecture)
- sl#3 (next step - validate sl against these patterns)